### PR TITLE
fixed #136

### DIFF
--- a/src/tools/gitversion/tool.ts
+++ b/src/tools/gitversion/tool.ts
@@ -103,7 +103,8 @@ export class GitVersionTool extends DotnetTool implements IGitVersionTool {
         }
 
         if (additionalArguments) {
-            args.push(additionalArguments)
+            //args.push(additionalArguments)
+            Array.prototype.push.apply(args,additionalArguments.split(' '))
         }
         return args
     }


### PR DESCRIPTION
Fixed bug #136 by splitting incoming "additionalArguments" before adding to the args array.

Prior to this change, when multiple arguments are provided in azure-pipelines.yaml they were passed on to dotnet-gitversion.exe as a single, quoted argument, causing the exception noted in the bug.