### PR TITLE
Removed the path.join on srcDir and targetPath

### DIFF
--- a/src/tools/gitversion/tool.ts
+++ b/src/tools/gitversion/tool.ts
@@ -48,7 +48,7 @@ export class GitVersionTool extends DotnetTool implements IGitVersionTool {
             workDir = srcDir
         } else {
             if (this.buildAgent.directoryExists(targetPath)) {
-                workDir = path.join(srcDir, targetPath)
+                workDir = targetPath
             } else {
                 throw new Error('Directory not found at ' + targetPath)
             }


### PR DESCRIPTION
- Removed the path.join (srcDir, targetPath) in order to fix the bug with multiple checkouts #38 . 
Previous condition implicates use of absolute pathing here so this should be full path, not a join of srcDir and targetPath)