### PR TITLE
Find last json blob in gitversion stdout instead of first

### DIFF
--- a/src/tasks/gitversion/main.ts
+++ b/src/tasks/gitversion/main.ts
@@ -42,8 +42,8 @@ export async function run() {
         const result = await gitVersionTool.run(settings)
         const { stdout } = result
         const jsonOutput = stdout.substring(
-            stdout.indexOf('{'),
-            stdout.indexOf('}') + 1
+            stdout.lastIndexOf('{'),
+            stdout.lastIndexOf('}') + 1
         )
 
         const gitversion = JSON.parse(jsonOutput) as GitVersionOutput


### PR DESCRIPTION
Since curly brackets in commit messages of the last version tag is written to std out by the gitversion tool, only the last curly brackets should be used to find the json object that is written as well.
Fixes #370. 