### PR TITLE
Add ignore failed sources to possible arguments

### DIFF
--- a/dist/azure/gitreleasemanager/setup/task.json
+++ b/dist/azure/gitreleasemanager/setup/task.json
@@ -36,6 +36,14 @@
             "defaultValue": "false",
             "required": false,
             "helpMarkDown": "Include pre-release versions when matching a version"
+        },
+        {
+            "name": "ignoreFailedSources",
+            "type": "boolean",
+            "label": "Treat package source failures as warnings",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Treat package source failures as warnings"
         }
     ]
 }

--- a/dist/azure/gitversion/setup/task.json
+++ b/dist/azure/gitversion/setup/task.json
@@ -36,6 +36,14 @@
             "defaultValue": "false",
             "required": false,
             "helpMarkDown": "Include pre-release versions when matching a version"
+        },
+        {
+            "name": "ignoreFailedSources",
+            "type": "boolean",
+            "label": "Treat package source failures as warnings",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Treat package source failures as warnings"
         }
     ]
 }

--- a/docs/examples/azure/gitversion/setup/usage-examples.md
+++ b/docs/examples/azure/gitversion/setup/usage-examples.md
@@ -17,6 +17,10 @@ includePrerelease:
   description: Include pre-release versions when matching a version.
   required: false
   default: false
+ignoreFailedSources:
+  description: Treat package source failures as warnings.
+  required: false
+  default: false
 ```
 
 ---

--- a/docs/examples/github/gitversion/setup/usage-examples.md
+++ b/docs/examples/github/gitversion/setup/usage-examples.md
@@ -17,6 +17,10 @@ includePrerelease:
   description: Include pre-release versions when matching a version.
   required: false
   default: false
+ignoreFailedSources:
+  description: Treat package source failures as warnings.
+  required: false
+  default: false
 ```
 
 ---

--- a/gitreleasemanager/setup/action.yml
+++ b/gitreleasemanager/setup/action.yml
@@ -16,3 +16,7 @@ inputs:
     description: Include pre-release versions when matching a version
     required: false
     default: 'false'
+  ignoreFailedSources:
+    description: Treat package source failures as warnings.
+    required: false
+    default: 'false'

--- a/gitversion/setup/action.yml
+++ b/gitversion/setup/action.yml
@@ -16,3 +16,7 @@ inputs:
     description: Include pre-release versions when matching a version
     required: false
     default: 'false'
+  ignoreFailedSources:
+    description: Treat package source failures as warnings.
+    required: false
+    default: 'false'

--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -10,12 +10,14 @@ export const TYPES = {
 
 export enum SetupFields {
     includePrerelease = 'includePrerelease',
-    versionSpec = 'versionSpec'
+    versionSpec = 'versionSpec',
+    ignoreFailedSources = 'ignoreFailedSources'
 }
 
 export interface ISetupSettings {
     [SetupFields.versionSpec]: string
     [SetupFields.includePrerelease]: boolean
+    [SetupFields.ignoreFailedSources]: boolean
 }
 
 export interface IExecResult {

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -6,10 +6,14 @@ export class Settings {
         const includePrerelease = buildAgent.getBooleanInput(
             SetupFields.includePrerelease
         )
+        const ignoreFailedSources = buildAgent.getBooleanInput(
+            SetupFields.ignoreFailedSources
+        )
 
         return {
             versionSpec,
-            includePrerelease
+            includePrerelease,
+            ignoreFailedSources
         }
     }
 }

--- a/src/tasks/gitreleasemanager/main.ts
+++ b/src/tasks/gitreleasemanager/main.ts
@@ -23,10 +23,7 @@ export async function setup() {
 
         const settings = CommonSettings.getSetupSettings(buildAgent)
 
-        await gitReleaseManagerTool.install(
-            settings.versionSpec,
-            settings.includePrerelease
-        )
+        await gitReleaseManagerTool.install(settings)
 
         buildAgent.setSucceeded(
             'GitVersionManager installed successfully',

--- a/src/tasks/gitversion/main.ts
+++ b/src/tasks/gitversion/main.ts
@@ -20,10 +20,7 @@ export async function setup() {
 
         const settings = CommonSettings.getSetupSettings(buildAgent)
 
-        await gitVersionTool.install(
-            settings.versionSpec,
-            settings.includePrerelease
-        )
+        await gitVersionTool.install(settings)
 
         buildAgent.setSucceeded('GitVersion installed successfully', true)
     } catch (error) {

--- a/src/tools/gitreleasemanager/tool.ts
+++ b/src/tools/gitreleasemanager/tool.ts
@@ -1,6 +1,6 @@
 import path = require('path')
 
-import { TYPES, IBuildAgent, IExecResult } from '../../core/models'
+import { TYPES, IBuildAgent, IExecResult, ISetupSettings } from '../../core/models'
 import { injectable, inject } from 'inversify'
 import { DotnetTool, IDotnetTool } from '../../core/dotnet-tool'
 import { IVersionManager } from '../../core/versionManager'
@@ -16,7 +16,7 @@ import {
 } from './models'
 
 export interface IGitReleaseManagerTool extends IDotnetTool {
-    install(versionSpec: string, includePrerelease: boolean): Promise<void>
+    install(setupSettings: ISetupSettings): Promise<void>
     create(settings: GitReleaseManagerCreateSettings): Promise<IExecResult>
     discard(settings: GitReleaseManagerDiscardSettings): Promise<IExecResult>
     close(settings: GitReleaseManagerCloseSettings): Promise<IExecResult>
@@ -36,15 +36,11 @@ export class GitReleaseManagerTool
         super(buildAgent, versionManager)
     }
 
-    public async install(
-        versionSpec: string,
-        includePrerelease: boolean
-    ): Promise<void> {
+    public async install(setupSettings: ISetupSettings): Promise<void> {
         await this.toolInstall(
             'GitReleaseManager.Tool',
-            versionSpec,
             false,
-            includePrerelease
+            setupSettings
         )
     }
 

--- a/src/tools/gitversion/tool.ts
+++ b/src/tools/gitversion/tool.ts
@@ -1,13 +1,13 @@
 import path = require('path')
 
 import { injectable, inject } from 'inversify'
-import { IExecResult, IBuildAgent, TYPES } from '../../core/models'
+import { IExecResult, IBuildAgent, TYPES, ISetupSettings } from '../../core/models'
 import { DotnetTool, IDotnetTool } from '../../core/dotnet-tool'
 import { GitVersionSettings, GitVersionOutput } from './models'
 import { IVersionManager } from '../../core/versionManager'
 
 export interface IGitVersionTool extends IDotnetTool {
-    install(versionSpec: string, includePrerelease: boolean): Promise<void>
+    install(setupSettings: ISetupSettings): Promise<void>
     run(options: GitVersionSettings): Promise<IExecResult>
     writeGitVersionToAgent(gitversion: GitVersionOutput): void
 }
@@ -21,15 +21,11 @@ export class GitVersionTool extends DotnetTool implements IGitVersionTool {
         super(buildAgent, versionManager)
     }
 
-    public async install(
-        versionSpec: string,
-        includePrerelease: boolean
-    ): Promise<void> {
+    public async install(setupSettings: ISetupSettings): Promise<void> {
         await this.toolInstall(
             'GitVersion.Tool',
-            versionSpec,
             false,
-            includePrerelease
+            setupSettings
         )
     }
 


### PR DESCRIPTION
Hi,
in my company we are facing the following issue when using the `gitversion/setup` task on Azure Devops
```shell
/_work/_tool/dotnet/sdk/5.0.406/NuGet.targets(131,5): error : Unable to load the service index for source [private nuget repo]. 

Tool 'gitversion.tool' failed to install. This failure may have been caused by:
/_work/_tool/dotnet/sdk/5.0.406/NuGet.targets(131,5): error :   GSSAPI operation failed with error - Unspecified GSS failure.  Minor code may provide more information (SPNEGO cannot find mechanisms to negotiate).
```
This happens because for private repositories dotnet needs authentication to be able to read them and because the agent that is running this task has a global nuget configuration that we cannot ignore.

We workaround this issue by directly installing the tool with a bash command 
```shell
dotnet tool install GitVersion.Tool --version 5.9.0 --ignore-failed-sources
```
This parameter does what it says: ignore errors on failed sources, which in our case is fine because the tool is not present in our private repository.

This PR add the possibility to pass a new argument to the task that will add the parameter to the argument list of the dotnet command.
The default value is false, so it will not change the current behaviour of the task.