### PR TITLE
docs: error in `gitversion` `execute` usage example

### DIFF
--- a/docs/examples/github/gitversion/execute/usage-examples.md
+++ b/docs/examples/github/gitversion/execute/usage-examples.md
@@ -12,9 +12,9 @@ steps:
     with:
       fetch-depth: 0
 
-  - task: gittools/actions/gitversion/setup@v1.1.1
-    displayName: Install GitVersion
-    inputs:
+  - name: Install GitVersion
+    uses: gittools/actions/gitversion/setup@v1.1.1
+    with:
       versionSpec: '5.x'
 ```
 


### PR DESCRIPTION
I think the github actions gitversion instructions were copied from the Azure pipelines example so had the incorrect syntax