### PR TITLE
#1137 - use milestone for the action field for every GRM actions

### DIFF
--- a/src/tools/gitreleasemanager/models.ts
+++ b/src/tools/gitreleasemanager/models.ts
@@ -29,11 +29,11 @@ export enum OpenFields {
 }
 
 export enum PublishFields {
-    tagName = 'tagName'
+    milestone = 'milestone'
 }
 
 export enum AddAssetFields {
-    tagName = 'tagName',
+    milestone = 'milestone',
     assets = 'assets'
 }
 
@@ -66,10 +66,10 @@ export interface GitReleaseManagerOpenSettings extends GitReleaseManagerSettings
 }
 
 export interface GitReleaseManagerPublishSettings extends GitReleaseManagerSettings {
-    [PublishFields.tagName]: string
+    [PublishFields.milestone]: string
 }
 
 export interface GitReleaseManagerAddAssetSettings extends GitReleaseManagerSettings {
-    [AddAssetFields.tagName]: string
+    [AddAssetFields.milestone]: string
     [AddAssetFields.assets]: string[]
 }

--- a/src/tools/gitreleasemanager/settings.ts
+++ b/src/tools/gitreleasemanager/settings.ts
@@ -90,23 +90,23 @@ export class GitReleaseManagerSettingsProvider extends SettingsProvider implemen
     }
 
     public getPublishSettings(): GitReleaseManagerPublishSettings {
-        const tagName = this.buildAgent.getInput(PublishFields.tagName)
+        const milestone = this.buildAgent.getInput(PublishFields.milestone)
 
         const commonSettings = this.getCommonSettings()
         return {
             ...commonSettings,
-            tagName
+            milestone
         }
     }
 
     public getAddAssetSettings(): GitReleaseManagerAddAssetSettings {
-        const tagName = this.buildAgent.getInput(AddAssetFields.tagName)
+        const milestone = this.buildAgent.getInput(AddAssetFields.milestone)
         const assets = this.buildAgent.getListInput(AddAssetFields.assets)
 
         const commonSettings = this.getCommonSettings()
         return {
             ...commonSettings,
-            tagName,
+            milestone,
             assets
         }
     }

--- a/src/tools/gitreleasemanager/tool.ts
+++ b/src/tools/gitreleasemanager/tool.ts
@@ -184,8 +184,8 @@ export class GitReleaseManagerTool extends DotnetTool implements IGitReleaseMana
     private getPublishArguments(settings: GitReleaseManagerPublishSettings): string[] {
         const args: string[] = ['publish', ...this.getCommonArguments(settings)]
 
-        if (settings.tagName) {
-            args.push('--tagName', settings.tagName)
+        if (settings.milestone) {
+            args.push('--tagName', settings.milestone)
         }
 
         return args
@@ -194,8 +194,8 @@ export class GitReleaseManagerTool extends DotnetTool implements IGitReleaseMana
     private getAddAssetArguments(settings: GitReleaseManagerAddAssetSettings): string[] {
         const args: string[] = ['addasset', ...this.getCommonArguments(settings)]
 
-        if (settings.tagName) {
-            args.push('--tagName', settings.tagName)
+        if (settings.milestone) {
+            args.push('--tagName', settings.milestone)
         }
         if (settings.assets && settings.assets.length > 0) {
             settings.assets = settings.assets.map(asset => {


### PR DESCRIPTION
Made it consistent the fields used for the GRM actions

Fixes #1137 

Taking in consideration GRM does not have consistent arguments (some use `milestone` some `tagName`) we make it consistent in the GH Action, all tags or milestones will be `milestone`