### PR TITLE
increase max buffer of the output to 100 MB

### DIFF
--- a/src/agents/common/build-agent.ts
+++ b/src/agents/common/build-agent.ts
@@ -230,7 +230,7 @@ export abstract class BuildAgentBase implements IBuildAgent {
         const exec = util.promisify(execNonPromise)
 
         try {
-            const commandOptions: ExecOptions = { maxBuffer: 1024 * 1024 * 10 } // 10MB
+            const commandOptions: ExecOptions = { maxBuffer: 1024 * 1024 * 100 } // 100MB
             const { stdout, stderr } = await exec(`${cmd} ${args.join(' ')}`, commandOptions)
             return {
                 code: 0,


### PR DESCRIPTION
This pull request includes changes to improve the performance and reliability of the build agent by increasing the buffer size for command execution.

* [`src/agents/common/build-agent.ts`](diffhunk://#diff-aa98a07a4d627b62b0236f56dda4b98a56d1a88aef3b617344cd20d3428b3897L233-R233): Increased the `maxBuffer` size in `commandOptions` from 10MB to 100MB to handle larger outputs during command execution.
* Related 
  * #1336, 
  * #1237