### PR TITLE
Update oldTag retrieval in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           # Finding the version from release tag
 
           $newTag = "${{steps.gitversion.outputs.majorMinorPatch}}"
-          $oldTag = $(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1)).Trim("v")
+          $oldTag = cat package.json | ConvertFrom-Json | Select-Object -ExpandProperty version
           echo "Old tag: $oldTag"
           echo "New tag: $newTag"
 


### PR DESCRIPTION
Replaces the git-based method for fetching the previous version tag with a JSON extraction from package.json. This ensures consistency and avoids reliance on git commands for versioning.