### PR TITLE
#1495 - change name for AzDO tasks

### DIFF
--- a/dist/azure/gitreleasemanager/addasset/task.json
+++ b/dist/azure/gitreleasemanager/addasset/task.json
@@ -1,6 +1,6 @@
 {
   "id": "b803651c-21ac-4851-9fbf-c75b0e82e4c5",
-  "name": "gitreleasemanager/addasset",
+  "name": "gitreleasemanager-addasset",
   "friendlyName": "Add Asset GitReleaseManager Task",
   "description": "Tool for creating and exporting releases for software applications hosted on GitHub",
   "author": "GitTools Contributors",

--- a/dist/azure/gitreleasemanager/close/task.json
+++ b/dist/azure/gitreleasemanager/close/task.json
@@ -1,6 +1,6 @@
 {
   "id": "f5304356-f6e3-48e9-9b65-a9efa41ce7a2",
-  "name": "gitreleasemanager/close",
+  "name": "gitreleasemanager-close",
   "friendlyName": "Close GitReleaseManager Task",
   "description": "Tool for creating and exporting releases for software applications hosted on GitHub",
   "author": "GitTools Contributors",

--- a/dist/azure/gitreleasemanager/create/task.json
+++ b/dist/azure/gitreleasemanager/create/task.json
@@ -1,6 +1,6 @@
 {
   "id": "c77d38be-46a9-4ef1-a181-2d6050ed23d2",
-  "name": "gitreleasemanager/create",
+  "name": "gitreleasemanager-create",
   "friendlyName": "Create GitReleaseManager Task",
   "description": "Tool for creating and exporting releases for software applications hosted on GitHub",
   "author": "GitTools Contributors",

--- a/dist/azure/gitreleasemanager/discard/task.json
+++ b/dist/azure/gitreleasemanager/discard/task.json
@@ -1,6 +1,6 @@
 {
   "id": "9ae78b66-6100-4522-8106-b7ae00bbfcdf",
-  "name": "gitreleasemanager/discard",
+  "name": "gitreleasemanager-discard",
   "friendlyName": "Discard GitReleaseManager Task",
   "description": "Tool for creating and exporting releases for software applications hosted on GitHub",
   "author": "GitTools Contributors",

--- a/dist/azure/gitreleasemanager/open/task.json
+++ b/dist/azure/gitreleasemanager/open/task.json
@@ -1,6 +1,6 @@
 {
   "id": "5d437bf5-f193-4449-b531-c4c69eebaa48",
-  "name": "gitreleasemanager/open",
+  "name": "gitreleasemanager-open",
   "friendlyName": "Open GitReleaseManager Task",
   "description": "Tool for creating and exporting releases for software applications hosted on GitHub",
   "author": "GitTools Contributors",

--- a/dist/azure/gitreleasemanager/publish/task.json
+++ b/dist/azure/gitreleasemanager/publish/task.json
@@ -1,6 +1,6 @@
 {
   "id": "b3c54483-4140-45d8-b442-3a0b096b5f7f",
-  "name": "gitreleasemanager/publish",
+  "name": "gitreleasemanager-publish",
   "friendlyName": "Publish GitReleaseManager Task",
   "description": "Tool for creating and exporting releases for software applications hosted on GitHub",
   "author": "GitTools Contributors",

--- a/dist/azure/gitreleasemanager/setup/task.json
+++ b/dist/azure/gitreleasemanager/setup/task.json
@@ -1,6 +1,6 @@
 {
   "id": "e3022448-b00d-4b57-b504-606a0bcf8279",
-  "name": "gitreleasemanager/setup",
+  "name": "gitreleasemanager-setup",
   "friendlyName": "Setup GitReleaseManager Task",
   "description": "Tool for creating and exporting releases for software applications hosted on GitHub",
   "author": "GitTools Contributors",

--- a/dist/azure/gitversion/command/task.json
+++ b/dist/azure/gitversion/command/task.json
@@ -1,6 +1,6 @@
 {
   "id": "41dc3dd2-6a51-4ba5-a889-824274acca8b",
-  "name": "gitversion/command",
+  "name": "gitversion-command",
   "friendlyName": "Command GitVersion Task",
   "description": "Easy Semantic Versioning (https://semver.org) for projects using Git",
   "author": "GitTools Contributors",

--- a/dist/azure/gitversion/execute/task.json
+++ b/dist/azure/gitversion/execute/task.json
@@ -1,6 +1,6 @@
 {
   "id": "9013cf7f-ee8d-49f4-a39b-db244928d391",
-  "name": "gitversion/execute",
+  "name": "gitversion-execute",
   "friendlyName": "Execute GitVersion Task",
   "description": "Easy Semantic Versioning (https://semver.org) for projects using Git",
   "author": "GitTools Contributors",

--- a/dist/azure/gitversion/setup/task.json
+++ b/dist/azure/gitversion/setup/task.json
@@ -1,6 +1,6 @@
 {
   "id": "a06c02ae-7b9a-4082-90dc-fe27b500e54f",
-  "name": "gitversion/setup",
+  "name": "gitversion-setup",
   "friendlyName": "Setup GitVersion Task",
   "description": "Easy Semantic Versioning (https://semver.org) for projects using Git",
   "author": "GitTools Contributors",


### PR DESCRIPTION
Change the Azure DevOps tasks names from '/' to '-' to pass the validation.

This is a breaking change.

Closes #1495 