### PR TITLE
#1676 - fix -GitVersion configuration file not found at"

### DIFF
--- a/dist/azure/gitversion/execute/task.json
+++ b/dist/azure/gitversion/execute/task.json
@@ -71,6 +71,7 @@
       "name": "configFilePath",
       "type": "filePath",
       "label": "Configuration file",
+      "defaultValue": "",
       "required": false,
       "helpMarkDown": "Optional path to config file (defaults to GitVersion.yml)"
     },


### PR DESCRIPTION
An attempt at fixing #1676 