### PR TITLE
Update execute.md

### DIFF
--- a/docs/examples/azure/gitversion/execute.md
+++ b/docs/examples/azure/gitversion/execute.md
@@ -147,7 +147,7 @@ steps:
 Example contents of **GitVersion.yml**:
 
 ```yaml
-mode: Mainline
+mode: ContinuousDelivery
 branches:
   master:
     regex: ^latest$

--- a/docs/examples/github/gitversion/execute.md
+++ b/docs/examples/github/gitversion/execute.md
@@ -140,7 +140,7 @@ steps:
 Example contents of **GitVersion.yml**:
 
 ```yaml
-mode: Mainline
+mode: ContinuousDelivery
 branches:
   master:
     regex: ^latest$


### PR DESCRIPTION
In executing documentation GitVersion.yml is described with mode: "Mainline". Changing "Mainline" to "ContinuousDelivery" as Mainline is no longer a supported mode.