### PR TITLE
ci: pin gittools cicd action references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
         name: Check code quality
 
       - run: |
-          npm run build:tools
-          npm run build:agent:github
+          npm run build:tools &&
+          npm run build:agent:github &&
           npm run build:agent:azure
         name: Build code
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: gittools/cicd/checkout@v5
+        uses: gittools/cicd/checkout@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
         with:
           op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           fetch-depth: 0
@@ -115,7 +115,7 @@ jobs:
           echo "FullSemVer (steps.gitversion.outputs.GitVersion_FullSemVer) : ${{ steps.gitversion.outputs.GitVersion_FullSemVer }}"
         name: Use variables and output
 
-      - uses: gittools/cicd/git-commit-push@v5
+      - uses: gittools/cicd/git-commit-push@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
         if: matrix.os == 'ubuntu-24.04'
         with:
           message: 'dist update'

--- a/.github/workflows/examples-version.yml
+++ b/.github/workflows/examples-version.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: gittools/cicd/checkout@v5
+        uses: gittools/cicd/checkout@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
         with:
           op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           fetch-depth: 1
@@ -39,7 +39,7 @@ jobs:
           npm install --ignore-scripts
         name: Update examples version
 
-      - uses: gittools/cicd/git-commit-push@v5
+      - uses: gittools/cicd/git-commit-push@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
         with:
           message: "update examples version to ${{ github.event.client_payload.newTag }}"
         name: Commit and push updated examples version

--- a/.github/workflows/gitversion-published.yml
+++ b/.github/workflows/gitversion-published.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: gittools/cicd/checkout@v5
+        uses: gittools/cicd/checkout@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
         with:
           op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           fetch-depth: 1
@@ -40,7 +40,7 @@ jobs:
 
         name: Update GitVersion version
 
-      - uses: gittools/cicd/git-commit-push@v5
+      - uses: gittools/cicd/git-commit-push@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
         with:
           message: "update GitVersion version to ${{ github.event.client_payload.newTag }}"
         name: Commit and push updated GitVersion version

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Load TFX credentials
         id: tfx-creds
-        uses: gittools/cicd/tfx-creds@v5
+        uses: gittools/cicd/tfx-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
         with:
           op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Load GitHub App credentials
         id: github-app-creds
-        uses: gittools/cicd/github-app-creds@v5
+        uses: gittools/cicd/github-app-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
         with:
           op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,13 @@ jobs:
 
       - name: Load TFX credentials
         id: tfx-creds
-        uses: gittools/cicd/tfx-creds@v5
+        uses: gittools/cicd/tfx-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
         with:
           op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Load GitHub App credentials
         id: github-app-creds
-        uses: gittools/cicd/github-app-creds@v5
+        uses: gittools/cicd/github-app-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
         with:
           op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 


### PR DESCRIPTION
## Summary
- pin gittools/cicd workflow actions to the current v5 commit SHA
- keep the visible major version in inline comments for easier future updates
- address the Sonar TO_REVIEW hotspots for mutable action references

## Testing
- not run
