### PR TITLE
ci: build dist with the same command as the pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,7 @@ jobs:
         name: Check code quality
 
       - run: |
-          npm run build:tools &&
-          npm run build:agent:github &&
-          npm run build:agent:azure
+          npm run build
         name: Build code
 
       - run: |

--- a/dist/tools/libs/agents.mjs
+++ b/dist/tools/libs/agents.mjs
@@ -1,4 +1,4 @@
-import * as process$1 from "node:process";
+import * as process$2 from "node:process";
 import { execFile } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -1436,7 +1436,7 @@ var access = async (filePath) => {
 * @return {Promise<string>} Resolves the absolute file path just checked, or undefined.
 */
 var isExecutable = async (absPath, options = {}) => {
-	const extension = ((options.env || process$1.env).PATHEXT || "").split(path.delimiter).concat("");
+	const extension = ((options.env || process$2.env).PATHEXT || "").split(path.delimiter).concat("");
 	return (await Promise.all(extension.map(async (ext) => access(absPath + ext.toLowerCase())))).find((bin) => !!bin);
 };
 /**
@@ -1447,7 +1447,7 @@ var isExecutable = async (absPath, options = {}) => {
 * @return {string[]} Directories to dig into.
 */
 var getDirsToWalkThrough = (options) => {
-	return ((options.env || process$1.env)[process$1.platform === "win32" ? "Path" : "PATH"] || "").split(path.delimiter).concat(options.include || []).filter((p) => !(options.exclude || []).includes(p));
+	return ((options.env || process$2.env)[process$2.platform === "win32" ? "Path" : "PATH"] || "").split(path.delimiter).concat(options.include || []).filter((p) => !(options.exclude || []).includes(p));
 };
 /**
 * Returns async promise with absolute file path of given command,
@@ -1475,12 +1475,12 @@ var BuildAgentBase = class {
 		return this.getVariableAsPath(this.cacheDirVariable);
 	}
 	addPath(inputPath) {
-		const envName = process$1.platform === "win32" ? "Path" : "PATH";
-		const newPath = inputPath + path.delimiter + process$1.env[envName];
+		const envName = process$2.platform === "win32" ? "Path" : "PATH";
+		const newPath = inputPath + path.delimiter + process$2.env[envName];
 		this.debug(`new Path: ${newPath}`);
-		process$1.env[envName] = newPath;
-		process$1.env.Path = newPath;
-		this.info(`Updated PATH: ${process$1.env[envName]}`);
+		process$2.env[envName] = newPath;
+		process$2.env.Path = newPath;
+		this.info(`Updated PATH: ${process$2.env[envName]}`);
 	}
 	getInput(input, required) {
 		const inputProp = input.replaceAll(" ", "_").toUpperCase();
@@ -1500,7 +1500,7 @@ var BuildAgentBase = class {
 		return this.getDelimitedInput(input, "\n", required);
 	}
 	getVariable(name) {
-		const value = (process$1.env[name] || "").trim();
+		const value = (process$2.env[name] || "").trim();
 		this.debug(`getVariable - ${name}: ${value}`);
 		return value.trim();
 	}
@@ -1518,7 +1518,7 @@ var BuildAgentBase = class {
 	getExpandedString(pattern) {
 		const expanded = pattern.replace(/\$([A-Za-z_]\w*|{([A-Za-z_]\w*)})/g, (_, whole, braced) => {
 			const name = braced ?? whole;
-			const value = process$1.env[name.toUpperCase()];
+			const value = process$2.env[name.toUpperCase()];
 			return value === void 0 ? "" : value;
 		});
 		this.debug(`getExpandedString - ${pattern}: ${expanded}`);


### PR DESCRIPTION
## Problem

`dist/tools/libs/agents.mjs` kept ping-ponging between two builds — the pre-commit hook and CI each rewrote it and reverted the other on every push. The only difference was a bundler-generated variable suffix: `process$1` ⇄ `process$2` (functionally identical).

### Root cause

All three agent builds (`local`/`azure`/`github`) emit the **same** shared chunk `dist/tools/libs/agents.mjs` (`agents/common` → `manualChunks: tools/libs/agents`, with `emptyOutDir: false`), so whichever agent builds **last** decides how rolldown numbers the `node:process` namespace import in that chunk.

The two paths ended on different agents:

| | Build command | Last agent | Suffix |
|---|---|---|---|
| Pre-commit hook | `npm run build` → `local → azure → github` | **github** | `process$2` |
| CI (before) | `build:tools && build:agent:github && build:agent:azure` | **azure** | `process$1` |

Since the last-built agent differed, the suffix flip-flopped and the two environments reverted each other indefinitely.

## Fix

Run `npm run build` in CI too, so both the hook and CI build `github` last and emit a **deterministic**, byte-identical bundle. Verified idempotent (two consecutive builds produce identical `agents.mjs`).

> Note: the `github` agent's default `import process from 'node:process'` is intentional — it assigns `process.exitCode`, which a namespace import forbids. Left unchanged; unifying the build command is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)